### PR TITLE
Allow process name to be overridden by log() argument

### DIFF
--- a/lib/node-syslog.js
+++ b/lib/node-syslog.js
@@ -53,17 +53,18 @@ this.Client.prototype = new(function () {
         }
     }
 
-    this.log = function (msg, severity) {
+    this.log = function (msg, severity, name) {
         var that = this;
         msg = msg.trim();
         severity = severity !== undefined ? severity : exports.LOG_INFO;
+        name = name !== undefined ? name : that.options.name;
 
         this.connect(function (e) {
             var pri = '<' + ((that.options.faculty * 8) + severity) + '>'; // Message priority
             var entry = pri + [
                 new(Date)().toJSON(),
                 hostname,
-                that.options.name + '[' + process.pid + ']:',
+                name + '[' + process.pid + ']:',
                 msg
             ].join(' ') + '\n';
 


### PR DESCRIPTION
Not a very standard syslog client API feature, but we like divide up a lot specialized logs by the process name field. This keeps us from having to create a lot of unnecessary connection objects. Would you consider merging this so that we can continue to use your NPM packages? Thanks for the consideration!
