### PR TITLE
Add additional logging facilities

### DIFF
--- a/lib/node-syslog.js
+++ b/lib/node-syslog.js
@@ -14,7 +14,31 @@ this.LOG_NOTICE = 5;
 this.LOG_INFO = 6;
 this.LOG_DEBUG = 7;
 
-this.FACILITY_USER = 1;
+// Log facility levels
+this.FACILITY_KERN = 0;       /* kernel messages */
+this.FACILITY_USER = 1;       /* random user-level messages */
+this.FACILITY_MAIL = 2;       /* mail systems */
+this.FACILITY_DAEMON = 3;     /* system daemons */
+this.FACILITY_AUTH = 4;       /* security/authorization messages */
+this.FACILITY_SYSLOG = 5;     /* messages generated internally by syslogd */
+this.FACILITY_LPR = 6;        /* line printer subsystem */
+this.FACILITY_NEWS = 7;       /* network news subsystem */
+this.FACILITY_UUCP = 8;       /* UUCP subsystem */
+this.FACILITY_CRON = 9;       /* clock daemon */
+this.FACILITY_AUTHPRIV = 10;  /* security/authorization messages (private) */
+this.FACILITY_FTP = 11;       /* ftp daemon */
+this.FACILITY_NTP = 12;       /* NTP subsystem */
+this.FACILITY_SECURITY = 13;  /* security subsystems (firewalling, etc.) */
+this.FACILITY_CONSOLE = 14;   /* /dev/console output */
+                              /* code 15 typically reserved for system use */
+this.FACILITY_LOCAL0 = 16;    /* reserved for local use */ 
+this.FACILITY_LOCAL1 = 17;    /* reserved for local use */
+this.FACILITY_LOCAL2 = 18;    /* reserved for local use */
+this.FACILITY_LOCAL3 = 19;    /* reserved for local use */
+this.FACILITY_LOCAL4 = 20;    /* reserved for local use */
+this.FACILITY_LOCAL5 = 21;    /* reserved for local use */
+this.FACILITY_LOCAL6 = 22;    /* reserved for local use */
+this.FACILITY_LOCAL7 = 23;    /* reserved for local use */
 
 this.DEFAULT_OPTIONS = {
     facility: exports.FACILITY_USER,
@@ -35,6 +59,12 @@ this.Client = function (port, host, options) {
 
     // We need to set this option here, incase the module is loaded before `process.title` is set.
     if (! this.options.name) { this.options.name = process.title || process.argv.join(' ') }
+
+    // Allow specifying facility name as a string
+    var facility_name = "FACILITY_" + this.options.facility;
+    if (facility_name in exports) {
+        this.options.facility = exports[facility_name];
+    }
 
     this.socket = null;
     this.retries = 0;


### PR DESCRIPTION
Hello,

This patch adds all the standard UNIX logging facilities and lets a user specify them by name or number when creating the logger.

for example:

```
syslog.createClient(514, 'localhost', {facility: "LOCAL0"});
```

This also fixes a bug where 'faculty' is used instead of 'facility'.

-Shaun
